### PR TITLE
chore: Use hardened local workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,5 +5,20 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    ignore:
+        - dependency-name: '*'
+          update-types: [version-update:semver-major]
     commit-message:
       prefix: 'deps'
+    groups:
+      fish-shop:
+        applies-to: version-updates
+        patterns:
+          - fish-shop/indent-check
+          - fish-shop/install-fish-shell
+          - fish-shop/install-plugin
+          - fish-shop/run-fishtape-tests
+          - fish-shop/syntax-check
+        update-types:
+          - minor
+          - patch

--- a/.github/workflows/dco-check.yml
+++ b/.github/workflows/dco-check.yml
@@ -17,7 +17,11 @@ jobs:
       - name: Harden the runner
         uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
         with:
-          egress-policy: audit
+          egress-policy: block
+          disable-sudo: true
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,6 +10,37 @@ permissions: {}
 
 jobs:
   check-fish:
-    uses: halostatue/halostatue/.github/workflows/fish-tests.yml@6cc8904b869c62229f9338c4fd75beeda12174ae # v1.1.0
+    name: Check Fish
+    runs-on: ubuntu-latest
+
     permissions:
       contents: read
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            api.launchpad.net:443
+            azure.archive.ubuntu.com:80
+            esm.ubuntu.com:443
+            github.com:443
+            packages.microsoft.com:443
+            ppa.launchpadcontent.net:443
+            raw.githubusercontent.com:443
+            registry.npmjs.org:443
+
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+        with:
+          persist-credentials: false
+
+      - uses: fish-shop/install-fish-shell@6bb2a3195509b2c33e2f8d057ab875f49cd37081 #v2.0.14
+      - uses: fish-shop/indent-check@965abe9686525131dfc7195cec5979ca0c213c54 #v2.2.60
+      - uses: fish-shop/syntax-check@c90721f4375aac460a0f73b1b8e837ccbccab0f5 #v2.2.59
+      - uses: fish-shop/install-plugin@48352eccd5d70a426292d9fdeab0e734f4b3bf82 #v2.3.62
+        with:
+          plugin-manager: fisher
+          plugins: IlanCosman/clownfish
+      - uses: fish-shop/run-fishtape-tests@7032926b1ab19d19f4dbf58cc5c7b8832b2c98c7 #v2.3.62

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -13,8 +13,39 @@ concurrency:
 
 jobs:
   zizmor:
-    uses: halostatue/halostatue/.github/workflows/zizmor.yml@6cc8904b869c62229f9338c4fd75beeda12174ae # v1.1.0
+    name: zizmor latest via uv
+    runs-on: ubuntu-latest
+
     permissions:
       security-events: write
       contents: read
       actions: read
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
+        with:
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            release-assets.githubusercontent.com:443
+            files.pythonhosted.org:443
+            github.com:443
+            objects.githubusercontent.com:443
+            pypi.org:443
+
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - uses: astral-sh/setup-uv@e92bafb6253dcd438e0484186d7669ea7a8ca1cc # v6.4.3
+
+      - run: uvx zizmor --persona pedantic --format sarif . > results.sarif
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: github/codeql-action/upload-sarif@51f77329afa6477de8c49fc9c7046c15b9a4e79d # v3.29.5
+        with:
+          sarif_file: results.sarif
+          category: zizmor


### PR DESCRIPTION
No longer using halostatue/halostatue workflows because of various issues with the workflow calls.
